### PR TITLE
Updated license details in home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -614,7 +614,7 @@ Find consensus on a license
 <p><a href="https://github.com/asciidoctor/asciidoctor">AsciiDoctor</a> renders this book</p>
 </li>
 <li>
-<p><a href="http://moonshinejs.org/">Moonshine</a>, licensed under the GNU GPL License, and</p>
+<p><a href="http://moonshinejs.org/">Moonshine</a>, licensed under MIT License, and</p>
 </li>
 <li>
 <p><a href="https://github.com/TannerRogalsky/punchdrunk">punchdrunk</a> by Tanner Rogalsky make LÖVE run in <strong>your</strong> browser</p>


### PR DESCRIPTION
Moonshine has recently changed its license. See https://github.com/gamesys/moonshine/commit/a310947a9b1207a076ecf437ec58ede88323edde.
